### PR TITLE
Fixed the issue where login via Github still prompted the user for their pwd

### DIFF
--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -41,6 +41,8 @@ class Dispatcher {
         self::$dispatcher->get('/team', array('Team'));
         self::$dispatcher->get('/timeline', array('Timeline'));
         self::$dispatcher->get('/welcome', array('Welcome'));
+        self::$dispatcher->any('/forgot', array('Forgot'));
+        self::$dispatcher->any('/resetpass', array('ResetPass'));
         self::$dispatcher->any('/login', array('Github', 'federated'));
         self::$dispatcher->any('/signup', array('Github', 'federated'));
 

--- a/lib/classes/User.php
+++ b/lib/classes/User.php
@@ -1749,6 +1749,17 @@ class User {
         return $this->auth_tokens[$github_id];
     }
 
+    public function findUserByGithubId($github_id) {
+        $cond =
+            '`id` = (
+                SELECT t.user_id
+                FROM `' . USERS_AUTH_TOKENS . "` t
+                WHERE t.github_id = '%s'
+            )";
+        $where = sprintf($cond, $github_id);
+        return $this->loadUser($where);
+    }
+
     public function findUserByAuthToken($token, $github_id = GITHUB_OAUTH2_CLIENT_ID) {
         $cond =
             '`id` = (
@@ -1907,7 +1918,7 @@ class User {
         return $pullRequestStatus;
     }
 
-    public static function signup($username, $nickname, $password, $access_token, $country) {
+    public static function signup($username, $nickname, $password, $access_token, $githubId, $country) {
         $sql = "
             INSERT
             INTO " . USERS  . " (username, nickname, password, confirm_string, added, w9_status, country, is_active)
@@ -1928,7 +1939,7 @@ class User {
         }
         $ret = new User($user_id);
         if ($ret->getId() && !$ret->isGithub_connected()) {
-            $ret->storeCredentials($access_token);
+            $ret->storeCredentials($access_token, $githubId);
         }
         return $ret;
     }

--- a/views/mustache/partials/modal/auth/authorize.mustache
+++ b/views/mustache/partials/modal/auth/authorize.mustache
@@ -17,6 +17,7 @@
             <div class="col-md-8">
               <input id="pass1" type="password" name="password" 
                 class="form-control" placeholder="Enter your password">
+              <h6><a href="/forgot">Forgot your password? Reset it here.</a></h6>
             </div>
           </div>
         </div>

--- a/views/mustache/safelogin.mustache
+++ b/views/mustache/safelogin.mustache
@@ -3,5 +3,6 @@
     <h2 class="form-signin-heading">Safe-mode sign in</h2>
     <input name="username" type="email" class="form-control" placeholder="Email address" required autofocus>
     <input name="password" type="password" class="form-control" placeholder="Password" required>
+    <h6><a href="/forgot">Forgot your password? Reset it here.</a></h6>
     <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
 </form>


### PR DESCRIPTION
At some point login system seems to have depended on Github re-using the same access token for the user. Since access tokens change on every login attempt this system breaks down. The only thing we can ensure is that the user id that github provides matches the access token of the user trying to login. We store github ids so that we can match up this information.

Considering that we haven't stored any github ids in the past the current users will still have to login once with their pwd and on subsequent login they'll just be let in as long as they are already on github.

In addition, many users forgot their original passwords. Enabled password reset and added links to it on all login forms.